### PR TITLE
need tls for calls to gmail

### DIFF
--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -193,6 +193,9 @@ class UserController {
                         user: process.env.EMAIL_ADDRESS,
                         pass: process.env.EMAIL_PASSWORD,
                     },
+                    tls: {
+                        rejectUnauthorized: false
+                    }
                 });
 
                 const mailOptions = {
@@ -305,6 +308,9 @@ class UserController {
                     user: process.env.EMAIL_ADDRESS,
                     pass: process.env.EMAIL_PASSWORD,
                 },
+                tls: {
+                    rejectUnauthorized: false
+                }
             });
         } catch {
             return res


### PR DESCRIPTION
It turns out gmail's sometimes rejection of the self-signed certificate is a nodemailer issue on localhost, and is not a rejection of our site. https://nodemailer.com/smtp/  for more info  By setting tls unauthorized to false in usercontroller's createTranport calls, we will have an encrypted way to communicate without rejects that sometimes happen in localhost mode.